### PR TITLE
Using a more updated Dockerimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:10-slim
+FROM alpine:3
 
 COPY entrypoint.sh /
 
-RUN apt-get update \
-  && apt-get install -y file \
+RUN apk update \
+  && apk add file git bash \
   && rm -rf /var/lib/apt/lists/* \
   && chmod +x /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3
+FROM debian:bookworm-slim
 
 COPY entrypoint.sh /
 
-RUN apk update \
-  && apk add file git bash \
+RUN apt-get update \
+  && apt-get install -y file \
   && rm -rf /var/lib/apt/lists/* \
   && chmod +x /entrypoint.sh
 


### PR DESCRIPTION
* After the build with debian 10 fails, this PR updates the whole thing to a current Alpine.

  Alpine for the reason that it is pleasantly slim for a CI server.